### PR TITLE
Add github acitons

### DIFF
--- a/.github/workflows/image-builder.yml
+++ b/.github/workflows/image-builder.yml
@@ -1,8 +1,8 @@
 name: ImageBuilderToHarbor
 on: [workflow_dispatch] # Can be changed, however for testing purposes it is set to workflow dispatch
 jobs:
-  findDockerFile:
-    runs-on: ubuntu-latest
+  findDockerFile: #Use python action to find dockerfiles
+    runs-on: ubuntu-latest # Will be changed to customer runner, after buildin infustructure
     outputs:
       matrix: ${{steps.python.outputs.myOutput}}
     steps:
@@ -12,21 +12,21 @@ jobs:
         id: python
         uses: vovsike/FirstAction@main
   buildDockerFile:
-    needs: findDockerFile
-    runs-on: ubuntu-latest
+    needs: findDockerFile #Needs first bit to lookup python images
+    runs-on: ubuntu-latest # Will be changed to customer runner, after buildin infustructure
     strategy:
       matrix:
         include: ${{ fromJson(needs.findDockerFile.outputs.matrix) }}
-    steps:
+    steps: #Logins to DockerGub or any other docker registry
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
-          registry: harbor.stfc.ac.uk
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.HARBOR_TOKEN }}
-      - name: Checkout repo
+          registry: harbor.stfc.ac.uk #Harbor is used as docker registry
+          username: ${{ secrets.DOCKERHUB_USERNAME }} #SECRETS
+          password: ${{ secrets.HARBOR_TOKEN }} #SECRETS
+      - name: Checkout repo #Used to get repo files into actions
         uses: actions/checkout@v1
-      - name: Build and push
+      - name: Build and push #Actual docker build using docker aciton
         id: docker_build
         uses: docker/build-push-action@v2
         continue-on-error: true


### PR DESCRIPTION
This PR will add github actions to the repo.

For this action to work it needs a set of secrets. These secretes can be setup in the repo itself.

One of the image build fails jupyter-datascience-notebook therefore a flag was added to ignore any errors `continue-on-error: true`. After fixing the image the flag needs to be removed.