### PR TITLE
RFI phd deps

### DIFF
--- a/jupyter-scipy-notebook/Dockerfile
+++ b/jupyter-scipy-notebook/Dockerfile
@@ -8,7 +8,11 @@ FROM jupyter/scipy-notebook
 USER root
 
 # install additional package...
-RUN apt-get update --yes && apt-get install --yes curl wget patch
+RUN apt-get update --yes && \
+    apt-get install --yes curl wget patch && \
+    rm -rf /var/lib/apt/lists/* && \
+    # RFI PHD 2022
+    pip install --no-cache-dir pysb
 
 # Switch back to jovyan to avoid accidental container runs as root
 USER ${NB_UID}

--- a/jupyter-scipy-notebook/Dockerfile
+++ b/jupyter-scipy-notebook/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update --yes && \
     apt-get install --yes curl wget patch && \
     rm -rf /var/lib/apt/lists/* && \
     # RFI PHD 2022
-    pip install --no-cache-dir pysb
+    pip install --no-cache-dir pysb && \
+    conda install -c alubbock bionetgen
 
 # Switch back to jovyan to avoid accidental container runs as root
 USER ${NB_UID}


### PR DESCRIPTION
They require the pysb image on the top of the Scipy image. Also clean up the apt-cache whilst constructing the image