### PR TITLE
Disable cache on prod builds

### DIFF
--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -46,8 +46,6 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' }}
         uses: docker/build-push-action@v3
         with:
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           push: true
           context: "{{defaultContext}}:${{ matrix.image }}"
           tags: "harbor.stfc.ac.uk/stfc-cloud/${{ matrix.image }}:latest"

--- a/jupyter-opengl/Dockerfile
+++ b/jupyter-opengl/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && \
 COPY requirements.yml .
 # Downgrade ipywidgets to less than 8 to avoid https://github.com/matplotlib/ipympl/issues/460
 RUN pip install --no-cache-dir --ignore-installed "ipywidgets>=7.0,<8"
-RUN conda env update --file requirements.yml && rm requirements.yml
+RUN mamba env update --file requirements.yml && rm requirements.yml
 
 ENV NVIDIA_DRIVER_CAPABILITIES compute,graphics,utility,video
 

--- a/jupyter-opengl/requirements.yml
+++ b/jupyter-opengl/requirements.yml
@@ -7,7 +7,6 @@ channels:
   - defaults
 dependencies:
   - cil
-  - scipy=1.7.3  # CIL prevents `GLIBCXX_3.4.30' not found
   - tomophantom=2.0.0
   - astra-toolbox
   - tigre=2.2

--- a/jupyter-opengl/requirements.yml
+++ b/jupyter-opengl/requirements.yml
@@ -14,6 +14,7 @@ dependencies:
   - ccpi-regulariser=21.0.0
   - xraylib # IBSim training
   - k3d # IBSim training
+  - psutil
   - pip
   - pip:
     - cma


### PR DESCRIPTION
This was causing all app layers to cache, so nothing was actually updating or pull in security / update wise.

Psutil was first to flag, as the compiled and installed versions no longer line up