### PR TITLE
add CIL notebook

### DIFF
--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -15,7 +15,7 @@ jobs:
       id: metadata
       run: |
         echo "images=$(
-          find -name Dockerfile -print0 | xargs -0 -II dirname "I" | sed 's#./##g' | jq -Rsc 'split("\n")[:-1]'
+          find -name Dockerfile | sed -r 's#\./(.+)/Dockerfile#\1#g' | jq -Rsc 'split("\n")[:-1]'
         )" >> $GITHUB_OUTPUT
         echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
     outputs:
@@ -31,7 +31,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: docker/setup-buildx-action@v2
-    - name: Login to DockerHub
+    - name: Login to DockerHub # increase pull rate limit
       uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -61,3 +61,7 @@ jobs:
     - name: Inform of tagged name
       if: ${{ github.ref != 'refs/heads/master' }}
       run: echo "::notice title=published::harbor.stfc.ac.uk/stfc-cloud-staging/${{ matrix.image }}:${{ needs.setup.outputs.sha }}"
+  finished: # convenient single job name to apply branch protection to
+    needs: build
+    runs-on: ubuntu-latest
+    steps: [{run: true}]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 ## CI and Automated Builds
 
+[![CI](https://img.shields.io/github/actions/workflow/status/stfc/cloud-docker-images/build_images.yaml?logo=docker)](https://github.com/stfc/cloud-docker-images/actions/workflows/build_images.yaml?query=branch%3Amaster)
+
 Images are built:
 
 - On Pull Requests

--- a/jupyter-cil-notebook/Dockerfile
+++ b/jupyter-cil-notebook/Dockerfile
@@ -6,7 +6,7 @@ FROM jupyter/tensorflow-notebook:ubuntu-20.04
 
 RUN mamba install -y -c conda-forge -c intel -c ccpi \
   cil=23.0.1 astra-toolbox tigre ccpi-regulariser tomophantom "ipywidgets<8" \
-  cudatoolkit jupyter-server-proxy \
+  jupyter-server-proxy \
   && mamba clean -a -y -f \
   && fix-permissions "${CONDA_DIR}" \
   && fix-permissions "/home/${NB_USER}"

--- a/jupyter-cil-notebook/Dockerfile
+++ b/jupyter-cil-notebook/Dockerfile
@@ -1,0 +1,15 @@
+# sources:
+# - https://github.com/jupyter/docker-stacks
+# - https://github.com/TomographicImaging/CIL#installation-of-cil
+# TODO: use `ubuntu-22.04` once `cil` adds `python=3.11` support
+FROM jupyter/tensorflow-notebook:ubuntu-20.04
+
+RUN mamba install -y -c conda-forge -c intel -c ccpi \
+  cil=23.0.1 astra-toolbox tigre ccpi-regulariser tomophantom "ipywidgets<8" \
+  cudatoolkit jupyter-server-proxy \
+  && mamba clean -a -y -f \
+  && fix-permissions "${CONDA_DIR}" \
+  && fix-permissions "/home/${NB_USER}"
+
+# Note, the trailing slash is important!
+ENV TENSORBOARD_PROXY_URL=/user-redirect/proxy/6006/


### PR DESCRIPTION
- couldn't use `:ubuntu-22.04` image because it comes with `python=3.11` (but `cil` needs `python<=3.10`)
- `harbor.stfc.ac.uk/stfc-cloud-staging/jupyter-cil-notebook:8d9624e` 7GB total size
  + (compared to `harbor.stfc.ac.uk/imaging-tomography/sirfcil` 20GB)

testing is welcome :) (I've only verified it works with https://github.com/TomographicImaging/CIL-Demos/blob/main/binder/TotalVariationDeblurring.ipynb)