### PR TITLE
Update tensorflow notebook to fix package dependency issues

### DIFF
--- a/jupyter-tensorflow-notebook/Dockerfile
+++ b/jupyter-tensorflow-notebook/Dockerfile
@@ -2,7 +2,10 @@
 FROM jupyter/tensorflow-notebook:ubuntu-22.04
 
 # pip install required packages
-RUN pip install jupyter-server-proxy tensorflow==2.12.0 tensorboard --no-cache-dir 
+# source: https://github.com/jupyter/docker-stacks
+RUN pip install jupyter-server-proxy tensorboard --no-cache-dir \
+    && fix-permissions "${CONDA_DIR}" \
+    && fix-permissions "/home/${NB_USER}"
 RUN pip install gym==0.25.2 pygame --no-cache-dir
 
 # Note, the trailing slash is important!

--- a/jupyter-tensorflow-notebook/Dockerfile
+++ b/jupyter-tensorflow-notebook/Dockerfile
@@ -1,24 +1,5 @@
 
 FROM jupyter/tensorflow-notebook:ubuntu-22.04
-# Switch to root to install packages
-
-USER root
-
-RUN apt-get update --yes \
-    && apt-get install -y --no-install-recommends \
-    nvidia-headless-515 \
-    nvidia-utils-515 \
-    libnvidia-gl-515-server \
-    libopengl0 \
-    && apt-get install --yes \
-    curl \
-    wget \
-    patch  \
-    nvidia-cuda-toolkit \
-    && rm -rf /var/lib/apt/lists/*
-
-# Switch back to jovyan to avoid accidental container runs as root
-USER ${NB_UID}
 
 # pip install required packages
 RUN pip install jupyter-server-proxy tensorflow tensorboard --no-cache-dir

--- a/jupyter-tensorflow-notebook/Dockerfile
+++ b/jupyter-tensorflow-notebook/Dockerfile
@@ -1,6 +1,17 @@
 
 FROM jupyter/tensorflow-notebook:ubuntu-22.04
+# Switch to root to install packages
 
+USER root
+
+RUN apt-get update --yes \
+    && apt-get install -y --no-install-recommends \
+    && apt-get install --yes nvidia-cuda-toolkit
+
+# Switch back to jovyan to avoid accidental container runs as root
+USER ${NB_UID}
+
+# pip install required packages
 RUN pip install jupyter-server-proxy tensorflow tensorboard --no-cache-dir
 RUN pip install gym==0.25.2 pygame --no-cache-dir
 

--- a/jupyter-tensorflow-notebook/Dockerfile
+++ b/jupyter-tensorflow-notebook/Dockerfile
@@ -6,7 +6,16 @@ USER root
 
 RUN apt-get update --yes \
     && apt-get install -y --no-install-recommends \
-    && apt-get install --yes nvidia-cuda-toolkit
+    nvidia-headless-515 \
+    nvidia-utils-515 \
+    libnvidia-gl-515-server \
+    libopengl0 \
+    && apt-get install --yes \
+    curl \
+    wget \
+    patch  \
+    nvidia-cuda-toolkit \
+    && rm -rf /var/lib/apt/lists/*
 
 # Switch back to jovyan to avoid accidental container runs as root
 USER ${NB_UID}

--- a/jupyter-tensorflow-notebook/Dockerfile
+++ b/jupyter-tensorflow-notebook/Dockerfile
@@ -2,7 +2,7 @@
 FROM jupyter/tensorflow-notebook:ubuntu-22.04
 
 # pip install required packages
-RUN pip install jupyter-server-proxy tensorflow tensorboard --no-cache-dir
+RUN pip install jupyter-server-proxy tensorflow==2.11.1 tensorboard --no-cache-dir 
 RUN pip install gym==0.25.2 pygame --no-cache-dir
 
 # Note, the trailing slash is important!

--- a/jupyter-tensorflow-notebook/Dockerfile
+++ b/jupyter-tensorflow-notebook/Dockerfile
@@ -2,7 +2,7 @@
 FROM jupyter/tensorflow-notebook:ubuntu-22.04
 
 # pip install required packages
-RUN pip install jupyter-server-proxy tensorflow==2.11.1 tensorboard --no-cache-dir 
+RUN pip install jupyter-server-proxy tensorflow==2.12.0 tensorboard --no-cache-dir 
 RUN pip install gym==0.25.2 pygame --no-cache-dir
 
 # Note, the trailing slash is important!


### PR DESCRIPTION
The tensorflow notebook is currently having some issues with tensorflow not being able to see GPUs. The nvidia drivers however are able to - this implies there are missing dependencies that tensorflow requires.

This PR modifies the `jupyter-tensorflow-notebook` dockerfile to install the specific packages tensorflow requires.