### PR TITLE
Get tensorboard working again

### DIFF
--- a/jupyter-tensorflow-notebook/Dockerfile
+++ b/jupyter-tensorflow-notebook/Dockerfile
@@ -15,8 +15,15 @@ RUN apt-get update && \
 
 USER ${NB_UID}
 
+# Required for Tensorboard on a remote container
+RUN mamba install --yes \
+    'jupyter-server-proxy' && \
+    mamba clean --all -f -y && \
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"
+
+# SciML requirements
 RUN pip install --user --no-cache-dir \
-    # SciML requirements
     gym==0.25.2 \
     pygame && \
     fix-permissions "${CONDA_DIR}" && \


### PR DESCRIPTION
    The new upstream image does not include the jupyter-server-proxy
    package, which is required to embed Tensorboard with the env var.
    
    Based on the upstream approach, install this using mamba then fix-up any
    perms we might have changed.