### PR TITLE
Use mamba install to install required packages for tensorflow notebook

### DIFF
--- a/jupyter-tensorflow-notebook/Dockerfile
+++ b/jupyter-tensorflow-notebook/Dockerfile
@@ -18,14 +18,10 @@ USER ${NB_UID}
 # Required for Tensorboard on a remote container
 RUN mamba install --yes \
     'jupyter-server-proxy' && \
+    # SciML requirements
+    mamba install --yes \
+    'gym=0.22' 'pygame' && \
     mamba clean --all -f -y && \
-    fix-permissions "${CONDA_DIR}" && \
-    fix-permissions "/home/${NB_USER}"
-
-# SciML requirements
-RUN pip install --user --no-cache-dir \
-    gym==0.25.2 \
-    pygame && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 


### PR DESCRIPTION
Pip install was not adding the packages required correctly. Using mamba install instead.