### PR TITLE
MAINT: Change to staging credentials

### DIFF
--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -21,8 +21,43 @@ jobs:
     outputs:
       images: ${{ steps.metadata.outputs.images }}
       sha: ${{ steps.metadata.outputs.sha_short }}
-  build:
+  build-staging:
     needs: setup
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.setup.outputs.images) }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: docker/setup-buildx-action@v2
+    - name: Login to DockerHub # increase pull rate limit
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Login to Harbor
+      uses: docker/login-action@v3
+      with:
+        registry: harbor.stfc.ac.uk
+        username: ${{ secrets.STAGING_HARBOR_USERNAME }}
+        password: ${{ secrets.STAGING_HARBOR_TOKEN }}
+    - name: Build & push to staging
+      if: ${{ github.ref != 'refs/heads/master' }}
+      uses: docker/build-push-action@v3
+      with:
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        push: true
+        context: "{{defaultContext}}:${{ matrix.image }}"
+        tags: "harbor.stfc.ac.uk/stfc-cloud-staging/${{ matrix.image }}:${{ needs.setup.outputs.sha }}"
+    - name: Inform of tagged name
+      if: ${{ github.ref != 'refs/heads/master' }}
+      run: echo "::notice title=published::harbor.stfc.ac.uk/stfc-cloud-staging/${{ matrix.image }}:${{ needs.setup.outputs.sha }}"
+    
+
+  build-prod:
+    needs: build-staging
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -49,19 +84,8 @@ jobs:
         push: true
         context: "{{defaultContext}}:${{ matrix.image }}"
         tags: "harbor.stfc.ac.uk/stfc-cloud/${{ matrix.image }}:latest"
-    - name: Build & push to staging
-      if: ${{ github.ref != 'refs/heads/master' }}
-      uses: docker/build-push-action@v3
-      with:
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
-        push: true
-        context: "{{defaultContext}}:${{ matrix.image }}"
-        tags: "harbor.stfc.ac.uk/stfc-cloud-staging/${{ matrix.image }}:${{ needs.setup.outputs.sha }}"
-    - name: Inform of tagged name
-      if: ${{ github.ref != 'refs/heads/master' }}
-      run: echo "::notice title=published::harbor.stfc.ac.uk/stfc-cloud-staging/${{ matrix.image }}:${{ needs.setup.outputs.sha }}"
-  finished: # convenient single job name to apply branch protection to
-    needs: build
-    runs-on: ubuntu-latest
-    steps: [{run: true}]
+    
+    finished: # convenient single job name to apply branch protection to
+      needs: build-prod
+      runs-on: ubuntu-latest
+      steps: [{run: true}]

--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       images: ${{ steps.metadata.outputs.images }}
       sha: ${{ steps.metadata.outputs.sha_short }}
-  build-staging:
+  build:
     needs: setup
     runs-on: ubuntu-latest
     strategy:
@@ -37,11 +37,19 @@ jobs:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Login to Harbor
+      if: ${{ github.ref != 'refs/heads/master' }}
       uses: docker/login-action@v3
       with:
         registry: harbor.stfc.ac.uk
         username: ${{ secrets.STAGING_HARBOR_USERNAME }}
         password: ${{ secrets.STAGING_HARBOR_TOKEN }}
+    - name: Login to Harbor
+      if: ${{ github.ref == 'refs/heads/master' }}
+      uses: docker/login-action@v3
+      with:
+        registry: harbor.stfc.ac.uk
+        username: ${{ secrets.HARBOR_USERNAME }}
+        password: ${{ secrets.HARBOR_TOKEN }}
     - name: Build & push to staging
       if: ${{ github.ref != 'refs/heads/master' }}
       uses: docker/build-push-action@v3
@@ -51,32 +59,6 @@ jobs:
         push: true
         context: "{{defaultContext}}:${{ matrix.image }}"
         tags: "harbor.stfc.ac.uk/stfc-cloud-staging/${{ matrix.image }}:${{ needs.setup.outputs.sha }}"
-    - name: Inform of tagged name
-      if: ${{ github.ref != 'refs/heads/master' }}
-      run: echo "::notice title=published::harbor.stfc.ac.uk/stfc-cloud-staging/${{ matrix.image }}:${{ needs.setup.outputs.sha }}"
-    
-
-  build-prod:
-    needs: build-staging
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        image: ${{ fromJson(needs.setup.outputs.images) }}
-    steps:
-    - uses: actions/checkout@v4
-    - uses: docker/setup-buildx-action@v2
-    - name: Login to DockerHub # increase pull rate limit
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - name: Login to Harbor
-      uses: docker/login-action@v3
-      with:
-        registry: harbor.stfc.ac.uk
-        username: ${{ secrets.HARBOR_USERNAME }}
-        password: ${{ secrets.HARBOR_TOKEN }}
     - name: Build & push to prod
       if: ${{ github.ref == 'refs/heads/master' }}
       uses: docker/build-push-action@v3
@@ -84,8 +66,11 @@ jobs:
         push: true
         context: "{{defaultContext}}:${{ matrix.image }}"
         tags: "harbor.stfc.ac.uk/stfc-cloud/${{ matrix.image }}:latest"
+    - name: Inform of tagged name
+      if: ${{ github.ref != 'refs/heads/master' }}
+      run: echo "::notice title=published::harbor.stfc.ac.uk/stfc-cloud-staging/${{ matrix.image }}:${{ needs.setup.outputs.sha }}"
+      finished: # convenient single job name to apply branch protection to
+        needs: build-prod
+        runs-on: ubuntu-latest
+        steps: [{run: true}]
     
-    finished: # convenient single job name to apply branch protection to
-      needs: build-prod
-      runs-on: ubuntu-latest
-      steps: [{run: true}]


### PR DESCRIPTION
Since the deprecation of the robot account we now need 2 separate logins for the staging/prod build&push. This means 2 separate jobs