### PR TITLE
BUG: Workflows still running on push

### DIFF
--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -1,6 +1,9 @@
 name: docker_images
 on:
   push:
+    paths-ignore:
+        - 'cloud-chatops/**'
+        - '.github/workflows/cloud_chatops.yaml'
   pull_request:
     paths-ignore:
       - 'cloud-chatops/**'


### PR DESCRIPTION
Workflows should not run on push or pull for cloud_chatops