### PR TITLE
Feat: Added a new cron-clone.sh script and edited the README.md file

### DIFF
--- a/cloud-chatops/INSTALL.md
+++ b/cloud-chatops/INSTALL.md
@@ -97,3 +97,27 @@ for the application to run before installing dependencies.
   # Run app
   python3 cloud-chatops/src/main.py prod
   ```
+
+### Automatic Container Update
+
+To pull the latest `docker-compose` file automatically, you can copy the `chatopscron` file into any of the `cron.< hourly | daily | weekly | monthly > directories found in `/etc`.
+
+Once created, you will need to change the file permissions accordingly:
+
+```shell
+  # Change into repo directory
+  cd cloud-docker-images/cloud-chatops
+
+  # Change permissions on script
+  chmod +x chatopscron
+
+  # Copy script to etc/cron.<timeframe>
+  sudo cp chatopscron /etc/cron.<timeframe>
+
+  # You can test that the script is running correctly by using this command.
+  run-parts /etc/cron.<timeframe>
+
+  #if you don't recieve any output, the script has not run.
+  ```
+
+*Please note when naming the file within /etc/cron.<timeframe> you cannot use file extenstions. Only valid characters are allowed [a-zA-Z]*

--- a/cloud-chatops/chatopscron
+++ b/cloud-chatops/chatopscron
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# When copying the contents of this file, remember to name the new file using only valid characters [a-zA-Z0-9_-]
+# Fullstops '.' and file extenstions are not permitted
+
+set -eux
+
+cd $HOME/cloud-docker-images/cloud-chatops
+git fetch && git clean -fxd && git reset --hard origin/master
+
+docker compose up -d
+
+echo "complete"


### PR DESCRIPTION
The cron-clone.sh script can be used to automatically pull docker-compose images via the cron.hourly, cron.daily, cron.weekly, or cron.monthly directories. The README files includes how to configure this.