### PR TITLE
DOC: Moved the ChatOps deployment steps and requirements to an INSTALL.md file

### DIFF
--- a/cloud-chatops/INSTALL.md
+++ b/cloud-chatops/INSTALL.md
@@ -1,5 +1,5 @@
-# Deploying a Cloud ChatOps application
-This document details the instructions to install and run ChatOps
+# Deploying Cloud ChatOps
+This document details the instructions to install dependencies and run the ChatOps application
 
 ## Contents:
 [Requirements](#requirements)<br>

--- a/cloud-chatops/INSTALL.md
+++ b/cloud-chatops/INSTALL.md
@@ -1,0 +1,100 @@
+# Deploying a Cloud ChatOps application
+This document details the instructions to install and run ChatOps
+
+## Contents:
+[Requirements](#requirements)<br>
+[Deployment](#deployment)<br>
+
+### Requirements:
+
+Two files required for the deployment of this application: `config.yml` and `secrets.json`.<br>
+These should be stored in `$HOME/cloud_chatops_secrets/` on the host system.<br>
+
+#### Config:
+The application configuration is stored in [config.yml](template_config.yml).
+This includes information such as username mapping, repositories to check and default values.<br>
+Slack Channel and Member IDs can be found in Slack by:<br>
+- Right-clicking the member / channel
+- View member / channel details
+- Near the bottom of the About tab there will be an ID with copy button
+
+The `config.yml` should look like the below:
+```yaml
+---
+maintainer: <maintainers_member_id>
+
+user-map:
+  <user_github_username>: <user_member_id>
+
+repos:
+  <organisation>:
+    - <repo>
+
+defaults:
+  author: <author_member_id>
+  channel: <reminder_channel_id>
+```
+#### Secrets:
+The `secrets.json` file should look like the below and there is a template [here](template_secrets.json)
+```json
+{
+  "SLACK_BOT_TOKEN": "<your-token>",
+  "SLACK_APP_TOKEN": "<your-token>",
+  "GITHUB_TOKEN": "<your-token>"
+}
+```
+Slack:<br>
+- TODO: How to create your own Slack application.<br>
+
+GitHub:<br>
+-  A GitHub Personal Access Token is needed to bypass rate limiting and allows access to private repositories.<br>
+- Documentation on how to create a GitHub personal access token can be found 
+[here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens).<br>
+
+
+### Deployment:
+The application can be run from a Docker image or source code. (Assuming running from project root)<br>
+
+#### Dependencies:
+* Docker 
+* Python 3.10+ (To run the application from source code)
+* Full list of required python packages can be found in [requirements.txt](requirements.txt)<br>
+
+#### Docker image:
+You can build the image locally or pull from [STFC Harbor](https://harbor.stfc.ac.uk/harbor/projects/33528/repositories/cloud-chatops).<br>
+Note: If you are pulling the image you will need to specify a version tag. 
+The latest version can be found in [version.txt](version.txt)<br>
+- ```shell
+  # Local build and run
+  docker build -t cloud_chatops cloud-chatops
+  docker run -v $HOME/cloud_chatops_secrets/:/usr/src/app/cloud_chatops_secrets/ cloud_chatops
+  ```
+- ```shell
+  # First log in to harbor
+  docker login -u <username> harbor.stfc.ac.uk
+  
+  # Then either:
+  
+  # Run container directly, specifying a version
+  docker run -v $HOME/cloud_chatops_secrets/:/usr/src/app/cloud_chatops_secrets/ harbor.stfc.ac.uk/stfc-cloud/cloud-chatops:<version> -d
+  #
+  # or
+  #
+  # Use Docker Compose in cloud-chatops folder, which will always contain latest image version
+  docker compose up -d
+  ```
+
+#### Running from source:
+You can run the code from [main.py](src/main.py).<br>
+It's always recommended to create a [virtual environment](https://docs.python.org/3/library/venv.html) 
+for the application to run before installing dependencies.
+- ```shell
+  # Install Venv module
+  python3 -m venv my_venv
+  # Activate venv
+  source my_venv/bin/activate
+  # Install requirements
+  pip3 install -r requirements.txt
+  # Run app
+  python3 cloud-chatops/src/main.py prod
+  ```

--- a/cloud-chatops/INSTALL.md
+++ b/cloud-chatops/INSTALL.md
@@ -56,9 +56,8 @@ GitHub:<br>
 The application can be run from a Docker image or source code. (Assuming running from project root)<br>
 
 #### Dependencies:
-* Docker 
-* Python 3.10+ (To run the application from source code)
-* Full list of required python packages can be found in [requirements.txt](requirements.txt)<br>
+* If running from a Docker image, ensure Docker is installed (see [installation guide](https://docs.docker.com/engine/install/)) and the user account is in the relevant docker users group 
+* If running the application from source, ensure Python 3.10 or higher is installed. The full list of required python packages can be found in [requirements.txt](requirements.txt)<br>
 
 #### Docker image:
 You can build the image locally or pull from [STFC Harbor](https://harbor.stfc.ac.uk/harbor/projects/33528/repositories/cloud-chatops).<br>
@@ -76,7 +75,7 @@ The latest version can be found in [version.txt](version.txt)<br>
   # Then either:
   
   # Run container directly, specifying a version
-  docker run -v $HOME/cloud_chatops_secrets/:/usr/src/app/cloud_chatops_secrets/ harbor.stfc.ac.uk/stfc-cloud/cloud-chatops:<version> -d
+  docker run -v $HOME/cloud_chatops_secrets/:/usr/src/app/cloud_chatops_secrets/ harbor.stfc.ac.uk/stfc-cloud/cloud-chatops:<version>
   #
   # or
   #

--- a/cloud-chatops/README.md
+++ b/cloud-chatops/README.md
@@ -6,7 +6,6 @@
 [About](#about)<br>
 [Usage / Features](#usage--features)<br>
 [Deployment](#deployment)<br>
-[requirements](#requirements)<br>
 
 ### About
 
@@ -31,103 +30,4 @@ Events are defined in the `main.py/schedule_jobs` function:<br>
 
 ### Deployment
 
-Secrets should always be stored in `$HOME/cloud_chatops_secrets` on the host system. Find out more about secrets [here](#Secrets)<br>
-The application can be run from a Docker image or source code. (Assuming running from project root)<br>
-
-#### Docker image:
-You can build the image locally or pull from [STFC Harbor](https://harbor.stfc.ac.uk/harbor/projects/33528/repositories/cloud-chatops).<br>
-Note: If you are pulling the image you will need to specify a version tag. 
-The latest version can be found in [version.txt](version.txt)<br>
-- ```shell
-  # Local build and run
-  docker build -t cloud_chatops cloud-chatops
-  docker run -v $HOME/cloud_chatops_secrets/:/usr/src/app/cloud_chatops_secrets/ cloud_chatops -d
-  ```
-- ```shell
-  # First log in to harbor
-  docker login -u <username> harbor.stfc.ac.uk
-  
-  # Then either:
-  
-  # Run container directly, specifying a version
-  docker run -v $HOME/cloud_chatops_secrets/:/usr/src/app/cloud_chatops_secrets/ harbor.stfc.ac.uk/stfc-cloud/cloud-chatops:<version> -d
-  #
-  # or
-  #
-  # Use Docker Compose in cloud-chatops folder, which will always contain latest image version
-  docker compose up -d
-  ```
-
-#### Running from source:
-You can run the code from [main.py](src/main.py).<br>
-It's always recommended to create a [virtual environment](https://docs.python.org/3/library/venv.html) 
-for the application to run before installing dependencies.
-- ```shell
-  # Install Venv module
-  python3 -m venv my_venv
-  # Activate venv
-  source my_venv/bin/activate
-  # Install requirements
-  pip3 install -r requirements.txt
-  # Run app
-  python3 cloud-chatops/src/main.py prod
-  ```
-
-### Requirements:
-
-Two files required for the deployment of this application: `config.yml` and `secrets.json`.<br>
-These should be stored in `$HOME/cloud_chatops_secrets` on the host system.<br>
-
-#### Config:
-The application configuration is stored in [config.yml](template_config.yml).
-This includes information such as username mapping, repositories to check and default values.<br>
-Slack Channel and Member IDs can be found in Slack by:<br>
-- Right-clicking the member / channel
-- View member / channel details
-- Near the bottom of the About tab there will be an ID with copy button
-
-The `config.yml` should look like the below:
-```yaml
----
-maintainer: AB12CD34  # Slack Member ID of the application maintainer
-
-user-map:  # Dictionary of GitHub username to Slack Member ID
-  my_github_username: AB12CD34
-  other_github_username: EF56GH78
-
-repos:  # Dictionary of owners and repositories
-  organisation1:
-    - repo1  # E.g. github.com/organisation1/repo1
-    - repo2
-    - repo3
-  organisation2:
-    - repo1  # E.g. github.com/organisation2/repo1
-    - repo2
-    - repo3
-
-defaults:  # Default values for application variables
-  # Default author will be assigned to pull requests where the PR author is not in the above user map.
-  # Usually team lead or senior staff member.
-  author: WX67YZ89  # Slack member ID
-  
-  # Default channel is where the pull requests will be posted.
-  # It's recommended to set this as a "maintenance" / "dev" channel in case the application goes awry.
-  # The actual channel messages are sent to can be specified in the code.
-  channel: CH12NN34  # Slack channel ID
-```
-#### Secrets:
-The `secrets.json` file should look like the below and there is a template [here](template_secrets.json)
-```json
-{
-  "SLACK_BOT_TOKEN": "<your-token>",
-  "SLACK_APP_TOKEN": "<your-token>",
-  "GITHUB_TOKEN": "<your-token>"
-}
-```
-Slack:<br>
-- TODO: How to create your own Slack application.<br>
-
-GitHub:<br>
--  A GitHub Personal Access Token is needed to bypass rate limiting and allows access to private repositories.<br>
-- Documentation on how to create a GitHub personal access token can be found 
-[here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens).<br>
+For instructions on how to install and deploy Cloud ChatOps, see [INSTALL.md](./INSTALL.md)

--- a/cloud-chatops/README.md
+++ b/cloud-chatops/README.md
@@ -30,4 +30,4 @@ Events are defined in the `main.py/schedule_jobs` function:<br>
 
 ### Deployment
 
-For instructions on how to install and deploy Cloud ChatOps, see [INSTALL.md](./INSTALL.md)
+For instructions on how to deploy Cloud ChatOps, see [INSTALL.md](./INSTALL.md)


### PR DESCRIPTION
The main changes made were:

* The deployment instructions and requirements were moved from README.md to INSTALL.md

* A few fixes were made for the local run instructions using docker. 

* A small `Dependencies` section was also added within `Deployment` to make sure users know of Python 3.10+ requirements (if running from source) and docker user group addition (if running via docker)