### PR TITLE
ENH: Add action to maximize build disk space

### DIFF
--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -35,6 +35,18 @@ jobs:
       matrix:
         image: ${{ fromJson(needs.setup.outputs.images) }}
     steps:
+    - name: Maximize build space # free up space for building images
+      uses: easimon/maximize-build-space@v10
+      with:
+        root-reserve-mb: 512
+        swap-size-mb: 1024
+        remove-dotnet: 'true'
+        remove-android: 'true'
+        remove-haskell: 'true'
+        remove-codeql: 'true'
+        build-mount-path: '/var/lib/docker/'
+    - name: Restart docker # restart the docker service
+      run: sudo service docker restart
     - uses: actions/checkout@v4
     - uses: docker/setup-buildx-action@v3
     - name: Login to DockerHub # increase pull rate limit


### PR DESCRIPTION
The GitHub runners were running out of space for building images as part of our GitHub workflows. This was causing issues as the GPU images are fairly big. 
This PR adds a workflow action to maximize build space and also restarts docker (following https://github.com/marketplace/actions/maximize-build-disk-space#usage)