### PR TITLE
BUG: CI Job failing on doc pr as lables aren't given

### DIFF
--- a/.github/workflows/cloud_chatops.yaml
+++ b/.github/workflows/cloud_chatops.yaml
@@ -100,6 +100,7 @@ jobs:
         with:
           app_version_path: "cloud-chatops/version.txt"
           docker_compose_path: "cloud-chatops/docker-compose.yaml"
+          labels: ${{ toJSON(github.event.pull_request.labels.*.name) }}
 
       - name: Log App Success
         if: ${{ env.app_updated == 'true' }}


### PR DESCRIPTION
Adds labels to the CI job parameters. This allows documentation and workflow PRs to not fail the version check.

This fixes #72 