### PR TITLE
Add find host slash command to manifest

### DIFF
--- a/cloud-chatops/app_manifest.yml
+++ b/cloud-chatops/app_manifest.yml
@@ -11,6 +11,9 @@ features:
       description: Get all open PRs
       usage_hint: "[all: every pr] [mine: your prs]"
       should_escape: false
+    - command: /find-host
+      description: Returns the IP of the host
+      should_escape: false
 oauth_config:
   scopes:
     bot:


### PR DESCRIPTION
### Description:

Adding the slash command to the app manifest if a user wants to deploy with the manifest. This should have been added in #85 

---

### Submitter:

Have you done the following?:

* [x] Labeled the pull request from the following? `major | minor | patch` or `documentation | workflow`
* [x] Updated the documentation and template config files?
* [ ] Added unit tests for new / untested code?
* [ ] Verified the relevant staging Docker image runs on `dev-cloud-chatops.nubes.rl.ac.uk`?

New / Existing features:
* [ ] Written integration tests?
* [ ] Configured the Slack Application with new commands or permission scope changes?
* [ ] Updated the `version.txt` and `docker-compose.yml` files?

---

### Reviewer:

Have you checked the following?:
* [ ] Version change is appropriate to the code changes? Semantic versioning documentation [here](https://semver.org/)
* [ ] Unit test code coverage is acceptable?
* [ ] Do the CI jobs pass?
