### PR TITLE
Bump Nvidia driver from 515 to 550

### DIFF
--- a/notebooks/jupyter-opengl/Dockerfile
+++ b/notebooks/jupyter-opengl/Dockerfile
@@ -6,9 +6,9 @@ USER root
 
 RUN apt-get update --yes \
     && apt-get install -y --no-install-recommends \
-    nvidia-headless-515 \
-    nvidia-utils-515 \
-    libnvidia-gl-515-server \
+    nvidia-headless-550 \
+    nvidia-utils-550 \
+    libnvidia-gl-550-server \
     libopengl0 && \
     apt-get install --no-install-recommends --yes \
     # The Nvidia cuda toolkit has to be installed after the driver to allow


### PR DESCRIPTION


### Description:
This better matches our GPU operator version that's deployed on JHub by bumping from 515 to 550

---

### Submitter:

Have you done the following?:

* [ ] Added a new directory in the project root with a `Dockerfile` inside?
* [x] Tested the image works?

---

### Reviewer:

Have you done the following?:

* [x] Does the `Dockerfile` install only the necessary packages?
* [x] Are the permissions of downloaded files onto the container appropriate?
* [x] Does the Dockerfile switch to `NB_UID` at the end of the file? (i.e the image is run as user, not root)
* [x] Has the image been built successfully and pushed to Harbor?
