### PR TITLE
MAINT: Changing the file path name in version_incrememnt.sh to match …

### DIFF
--- a/.github/workflows/bin/version_increment.sh
+++ b/.github/workflows/bin/version_increment.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 #reads the version.txt file and sets the version to the current version
-version=`cat ~0/OpenStack-Rabbit-Consumer/version.txt`
+version=`cat ~0/openstack-rabbit-consumer/version.txt`
 
 # cuts the $version variable into major, minor and patch numbers, removing the fullstop
 major=$(echo $version | cut -f1 -d.)
@@ -17,4 +17,4 @@ patch=$((patch + 1))
 newversion="$major.$minor.$patch"
 
 #overwrites the version.txt file with new new version
-printf "$newversion" > ~0/OpenStack-Rabbit-Consumer/version.txt
+printf "$newversion" > ~0/openstack-rabbit-consumer/version.txt


### PR DESCRIPTION
…the correct one

The old Rabbit Consumer Schedule runner I created was moved over to this new repo but the path was not the same for the version.txt file. openstack-rabbit-consumer is now all in lowercase and therefore was failing the action.

Click the `Preview` tab and select a PR template:

- [PR for Cloud ChatOps](?expand=1&template=chatops_pr_template.md)
- [PR for notebook image](?expand=1&template=notebook_pr_template.md)
