### PR TITLE
BUG: Fixing ral.error message not being consumer by rabbit consumers

### DIFF
--- a/openstack-rabbit-consumer/rabbit_consumer/message_consumer.py
+++ b/openstack-rabbit-consumer/rabbit_consumer/message_consumer.py
@@ -303,6 +303,8 @@ def initiate_consumer() -> None:
             for exchange in exchanges:
                 logger.debug("Binding to exchange: %s", exchange)
                 queue.bind(exchange, routing_key="ral.info")
+                queue.bind(exchange, routing_key="ral.error")
+
 
             # Consume the messages from generator
             message: rabbitpy.Message

--- a/openstack-rabbit-consumer/tests/test_message_consumer.py
+++ b/openstack-rabbit-consumer/tests/test_message_consumer.py
@@ -185,6 +185,7 @@ def test_initiate_consumer_channel_setup(rabbitpy, gen_login, _, mocked_config):
     rabbitpy.Queue.assert_called_once_with(channel, name="ral.info", durable=True)
     queue = rabbitpy.Queue.return_value
     queue.bind.assert_called_once_with("nova", routing_key="ral.info")
+    queue.bind.assert_called_once_with("nova", routing_key="ral.error")
 
 
 @patch("rabbit_consumer.message_consumer.verify_kerberos_ticket")

--- a/openstack-rabbit-consumer/tests/test_message_consumer.py
+++ b/openstack-rabbit-consumer/tests/test_message_consumer.py
@@ -184,8 +184,7 @@ def test_initiate_consumer_channel_setup(rabbitpy, gen_login, _, mocked_config):
 
     rabbitpy.Queue.assert_called_once_with(channel, name="ral.info", durable=True)
     queue = rabbitpy.Queue.return_value
-    queue.bind.assert_called_once_with("nova", routing_key="ral.info")
-    queue.bind.assert_called_once_with("nova", routing_key="ral.error")
+    queue.bind.assert_has_calls([call('nova', routing_key='ral.info'), call('nova', routing_key='ral.error')])
 
 
 @patch("rabbit_consumer.message_consumer.verify_kerberos_ticket")


### PR DESCRIPTION
Added a queue.bind with the routing_key set to "ral.error" and a assertion in the unit tests for it. Didn't change the name of the queue from "ral.info" to something like ral.info.and.error since I thought ral.info is still valid.

Click the `Preview` tab and select a PR template:

- [PR for Cloud ChatOps](?expand=1&template=chatops_pr_template.md)
- [PR for notebook image](?expand=1&template=notebook_pr_template.md)
