### PR TITLE
BUG: Changed the queue.bind to look for ral.*

### DIFF
--- a/openstack-rabbit-consumer/rabbit_consumer/message_consumer.py
+++ b/openstack-rabbit-consumer/rabbit_consumer/message_consumer.py
@@ -302,9 +302,7 @@ def initiate_consumer() -> None:
             queue = rabbitpy.Queue(channel, name="ral.info", durable=True)
             for exchange in exchanges:
                 logger.debug("Binding to exchange: %s", exchange)
-                queue.bind(exchange, routing_key="ral.info")
-                queue.bind(exchange, routing_key="ral.error")
-
+                queue.bind(exchange, routing_key="ral.*")
 
             # Consume the messages from generator
             message: rabbitpy.Message

--- a/openstack-rabbit-consumer/tests/test_message_consumer.py
+++ b/openstack-rabbit-consumer/tests/test_message_consumer.py
@@ -184,7 +184,7 @@ def test_initiate_consumer_channel_setup(rabbitpy, gen_login, _, mocked_config):
 
     rabbitpy.Queue.assert_called_once_with(channel, name="ral.info", durable=True)
     queue = rabbitpy.Queue.return_value
-    queue.bind.assert_has_calls([call('nova', routing_key='ral.info'), call('nova', routing_key='ral.error')])
+    queue.bind.assert_has_calls(call('nova', routing_key='ral.*')
 
 
 @patch("rabbit_consumer.message_consumer.verify_kerberos_ticket")

--- a/openstack-rabbit-consumer/tests/test_message_consumer.py
+++ b/openstack-rabbit-consumer/tests/test_message_consumer.py
@@ -184,7 +184,7 @@ def test_initiate_consumer_channel_setup(rabbitpy, gen_login, _, mocked_config):
 
     rabbitpy.Queue.assert_called_once_with(channel, name="ral.info", durable=True)
     queue = rabbitpy.Queue.return_value
-    queue.bind.assert_has_calls(call('nova', routing_key='ral.*')
+    queue.bind.assert_called_once_with('nova', routing_key='ral.*')
 
 
 @patch("rabbit_consumer.message_consumer.verify_kerberos_ticket")


### PR DESCRIPTION
Binding ral.error didn't work and the messages weren't being consumed, therefore I have removed the ral.error and changed ral.info to ral.* to test whether this will consume both messages.
