### PR TITLE
Updating the github workflow runner image

### DIFF
--- a/.github/workflows/cloud_chatops.yaml
+++ b/.github/workflows/cloud_chatops.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-20.04','ubuntu-22.04']
+        os: ['ubuntu-22.04','ubuntu-latest']
         python-version: [ "3.12", "3.x" ]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION


### Description:

Ubuntu 20 runners are now retired and we are running the image on Ubuntu 22 machines in the Cloud anyways

---

### Submitter:

Have you done the following?:

* [x] Labeled the pull request from the following? `major | minor | patch` or `documentation | workflow`

---

### Reviewer:

Have you checked the following?:
* [ ] Do the CI jobs pass?
