### PR TITLE
Change all tags from workflows to pinned SHAs

### DIFF
--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -18,7 +18,7 @@ jobs:
     if: github.event_name != 'pull_request' || !contains('OWNER,MEMBER,COLLABORATOR', github.event.pull_request.author_association)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }} # fix SHA
       - name: List all images
@@ -40,7 +40,7 @@ jobs:
         image: ${{ fromJson(needs.setup.outputs.images) }}
     steps:
       - name: Maximize build space # free up space for building images
-        uses: easimon/maximize-build-space@v10
+        uses: easimon/maximize-build-space@fc881a613ad2a34aca9c9624518214ebc21dfc0c
         with:
           root-reserve-mb: 512
           swap-size-mb: 1024
@@ -51,30 +51,30 @@ jobs:
           build-mount-path: "/var/lib/docker/"
       - name: Restart docker # restart the docker service
         run: sudo service docker restart
-      - uses: actions/checkout@v6
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
       - name: Login to DockerHub # increase pull rate limit
-        uses: docker/login-action@v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Login to Harbor Staging
         if: ${{ github.ref != 'refs/heads/master' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
         with:
           registry: harbor.stfc.ac.uk
           username: ${{ secrets.STAGING_HARBOR_USERNAME }}
           password: ${{ secrets.STAGING_HARBOR_TOKEN }}
       - name: Login to Harbor
         if: ${{ github.ref == 'refs/heads/master' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
         with:
           registry: harbor.stfc.ac.uk
           username: ${{ secrets.HARBOR_USERNAME }}
           password: ${{ secrets.HARBOR_TOKEN }}
       - name: Build & push to staging
         if: ${{ github.ref != 'refs/heads/master' }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
         with:
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -83,7 +83,7 @@ jobs:
           tags: "harbor.stfc.ac.uk/stfc-cloud-staging/${{ matrix.image }}:${{ needs.setup.outputs.sha }}"
       - name: Build & push to prod
         if: ${{ github.ref == 'refs/heads/master' }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
         with:
           push: true
           context: "{{defaultContext}}:${{ matrix.image }}"

--- a/.github/workflows/cloud_chatops.yaml
+++ b/.github/workflows/cloud_chatops.yaml
@@ -68,8 +68,8 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Login to Harbor
-      # https://github.com/docker/login-action/releases
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
+      # https://github.com/docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2/releases
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
         with:
           registry: harbor.stfc.ac.uk
           username: ${{ secrets.STAGING_HARBOR_USERNAME }}
@@ -131,7 +131,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Login to Harbor
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
         with:
           registry: harbor.stfc.ac.uk
           username: ${{ secrets.HARBOR_USERNAME }}
@@ -142,7 +142,7 @@ jobs:
         run: echo "version=$(cat cloud-chatops/version.txt)" >> $GITHUB_OUTPUT
 
       - name: Check if release file has updated
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@9d7afb8d214ad99e78fbd4247752c4caed2b6e4c
         id: release_updated
         with:
           filters: |

--- a/.github/workflows/cloud_monitoring.yaml
+++ b/.github/workflows/cloud_monitoring.yaml
@@ -18,9 +18,9 @@ jobs:
         python-version: [ "3.12", "3.x" ]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
@@ -48,7 +48,7 @@ jobs:
           python -m pytest tests --cov-report xml:coverage.xml --cov
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           files: cloud-chatops/coverage.xml
@@ -57,16 +57,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: test_and_lint
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Checkout the code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Login to Harbor
-        uses: docker/login-action@v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
         with:
           registry: harbor.stfc.ac.uk
           username: ${{ secrets.STAGING_HARBOR_USERNAME }}
@@ -77,7 +77,7 @@ jobs:
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Build and push to staging project
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
         with:
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -91,7 +91,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0  # Needed for tags
 
@@ -141,7 +141,7 @@ jobs:
 
       - name: Bump version (patch)
         if: steps.check_bump.outputs.same == 'true'
-        uses: callowayproject/bump-my-version@master
+        uses: callowayproject/bump-my-version@e6ecdc3e573698766cd6c2112faeda50bcc2e56a
         id: bump
         with:
           args: patch
@@ -171,17 +171,17 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Login to Harbor
-        uses: docker/login-action@v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
         with:
           registry: harbor.stfc.ac.uk
           username: ${{ secrets.HARBOR_USERNAME }}
           password: ${{ secrets.HARBOR_TOKEN }}
 
       - name: Build and push on version change
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
         if: steps.release_updated.outputs.version == 'true'
         with:
           cache-from: type=gha

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -55,11 +55,11 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -87,6 +87,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/rabbit_consumer.yaml
+++ b/.github/workflows/rabbit_consumer.yaml
@@ -16,9 +16,9 @@ jobs:
       matrix:
         python-version: ["3.10"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
@@ -43,7 +43,7 @@ jobs:
           cd openstack-rabbit-consumer && python -m coverage xml
 
       - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
         with:
           files: openstack-rabbit-consumer/coverage.xml
           fail_ci_if_error: true
@@ -54,13 +54,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: test_and_lint
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Login to Harbor
-        uses: docker/login-action@v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
         with:
           registry: harbor.stfc.ac.uk
           username: ${{ secrets.STAGING_HARBOR_USERNAME }}
@@ -71,7 +71,7 @@ jobs:
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Build and push to staging project
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
         with:
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -87,13 +87,13 @@ jobs:
     needs: test_and_lint
     if: github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Login to Harbor
-        uses: docker/login-action@v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
         with:
           registry: harbor.stfc.ac.uk
           username: ${{ secrets.HARBOR_USERNAME }}
@@ -104,7 +104,7 @@ jobs:
         run: echo "version=$(cat openstack-rabbit-consumer/version.txt)" >> $GITHUB_OUTPUT
 
       - name: Check if release file has updated
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@9d7afb8d214ad99e78fbd4247752c4caed2b6e4c
         id: release_updated
         with:
           filters: |
@@ -112,7 +112,7 @@ jobs:
               - 'openstack-rabbit-consumer/version.txt'
 
       - name: Build and push on version change
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
         if: steps.release_updated.outputs.version == 'true'
         with:
           cache-from: type=gha

--- a/.github/workflows/rabbit_consumer_chart_schedule.yaml
+++ b/.github/workflows/rabbit_consumer_chart_schedule.yaml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         python-version: ["3.10"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
@@ -44,13 +44,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: test_and_lint
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Login to Harbor
-        uses: docker/login-action@v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
         with:
           registry: harbor.stfc.ac.uk
           username: ${{ secrets.HARBOR_USERNAME }}
@@ -65,7 +65,7 @@ jobs:
         run: echo "version=$(cat openstack-rabbit-consumer/version.txt)" >> $GITHUB_OUTPUT
 
       - name: Build and push on version change
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
         if: steps.release_updated.outputs.version == 'true'
         with:
           cache-from: type=gha
@@ -79,7 +79,7 @@ jobs:
         run: echo "Image published to harbor.stfc.ac.uk/stfc-cloud/openstack-rabbit-consumer-schedule:v${{ steps.release_tag.outputs.version }}"
       
       - name: Commit Changes
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321
         with:
           add: ${{ github.workspace }}/openstack-rabbit-consumer/version.txt
           default_author: github_actions

--- a/.github/workflows/username_service.yaml
+++ b/.github/workflows/username_service.yaml
@@ -15,25 +15,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9.2.0
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20
         with:
           working-directory: stfc-username-service/
 
   run_tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Run tests in container
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
         with:
           no-cache: true
           cache-to: type=gha,mode=max
@@ -45,13 +45,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [run_tests, golangci-lint]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Login to Harbor
-        uses: docker/login-action@v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
         with:
           registry: harbor.stfc.ac.uk
           username: ${{ secrets.STAGING_HARBOR_USERNAME }}
@@ -62,7 +62,7 @@ jobs:
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Build and push to staging project
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
         with:
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -78,13 +78,13 @@ jobs:
     needs: [run_tests, golangci-lint]
     if: github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Login to Harbor
-        uses: docker/login-action@v3
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
         with:
           registry: harbor.stfc.ac.uk
           username: ${{ secrets.HARBOR_USERNAME }}
@@ -95,7 +95,7 @@ jobs:
         run: echo "version=$(cat stfc-username-service/version.txt)" >> $GITHUB_OUTPUT
 
       - name: Check if release file has updated
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@9d7afb8d214ad99e78fbd4247752c4caed2b6e4c
         id: release_updated
         with:
           filters: |
@@ -103,7 +103,7 @@ jobs:
               - 'stfc-username-service/version.txt'
 
       - name: Build and push on version change
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
         if: steps.release_updated.outputs.version == 'true'
         with:
           cache-from: type=gha


### PR DESCRIPTION
- Change all of the tags in the repo to pinned SHAs as it is best practice as a defence against supply chain attacks

### Description:

<!--
This should be a brief one or two line description of the PR. Details should be contained in commit messages.
-->

---

### Submitter:

<!-- Please delete as appropriate. -->


Have you done the following?:

* [ ] Labeled the pull request from the following? `major | minor | patch` or `documentation | workflow`
* [ ] Updated the documentation?
* [ ] Added unit tests for new / untested code?
* [ ] Deployed the changes onto `dev-chatops.nubes.rl.ac.uk`?

New / Existing features:
* [ ] Written integration tests?
* [ ] Configured the Slack Application with new commands or permission scope changes?
* [ ] Updated the `version.txt` and `docker-compose.yml` files?

---

### Reviewer:

Have you checked the following?:
* [ ] Version change is appropriate to the code changes? Semantic versioning documentation [here](https://semver.org/)
* [ ] Unit test code coverage is acceptable?
* [ ] Do the CI jobs pass?
